### PR TITLE
Match robot.txt location to others in nixpkgs

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -62,7 +62,7 @@ in {
               };
               config = lib.mkMerge [
                 (lib.mkIf (config.blockAgents.enable && (length config.blockAgents.agents) > 0) {
-                  locations."=/robots.txt" = lib.mkIf config.blockAgents.robotsTxt.enable {
+                  locations."= /robots.txt" = lib.mkIf config.blockAgents.robotsTxt.enable {
                     alias = mkRobotsTxt config.blockAgents.agents;
                   };
                   extraConfig = let


### PR DESCRIPTION
Thanks for this module, it's super helpful!

While trying it out I noticed the robots.txt generation failed on services that have their own robots.txt rules, as nixpkgs uses different whitespace:

https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20%22%3D%20%2Frobots.txt%22&type=code

I've adjusted the config to match that